### PR TITLE
feat(sdk): add multipart image send support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ interface ClientConfig {
 }
 ```
 
+### Remote Server Setup
+
+If your SDK code runs on a different machine than the iMessage server:
+
+- `serverUrl` points to the server machine
+- `filePath` points to the SDK machine
+
+The SDK reads local files first, then uploads the file bytes to the server.
+
 ---
 
 ## Core Concepts
@@ -611,6 +620,38 @@ const message = await sdk.attachments.sendAttachment({
   fileName: "custom-name.jpg", // Optional
 });
 ```
+
+### Send Multiple Images In One Request
+
+Use `sendMultipartMessage()` when you want to send multiple images together as one multipart iMessage request:
+
+```typescript
+const message = await sdk.messages.sendMultipartMessage({
+  chatGuid: "iMessage;+;chat123456789",
+  parts: [
+    {
+      partIndex: 0,
+      filePath: "/path/to/image-1.jpg",
+    },
+    {
+      partIndex: 1,
+      filePath: "/path/to/image-2.jpg",
+    },
+    {
+      partIndex: 2,
+      filePath: "/path/to/image-3.jpg",
+    },
+  ],
+});
+```
+
+Notes:
+- `sendMultipartMessage()` uploads each file first, then sends all parts together in a single `/api/v1/message/multipart` request.
+- This requires the Private API path on the server.
+- The target `chatGuid` must already exist. If you only have a phone number/email, create or fetch the chat first.
+- If the SDK and server are on different machines, each `filePath` must exist on the SDK machine. The SDK uploads the file bytes to the server before sending.
+
+> Example: [message-multipart-images.ts](./examples/message-multipart-images.ts)
 
 ### Send Audio Messages
 

--- a/examples/message-multipart-images.ts
+++ b/examples/message-multipart-images.ts
@@ -51,6 +51,8 @@ async function main() {
             console.log(`${new Date(message.dateCreated).toLocaleString()}`);
         } catch (error) {
             handleError(error, "Failed to send multipart images");
+            await sdk.close();
+            process.exit(1);
         }
 
         await sdk.close();
@@ -60,4 +62,7 @@ async function main() {
     await sdk.connect();
 }
 
-main().catch(console.error);
+main().catch((error) => {
+    handleError(error, "Failed to start multipart image example");
+    process.exit(1);
+});

--- a/examples/message-multipart-images.ts
+++ b/examples/message-multipart-images.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createSDK, handleError } from "./utils";
+
+const CHAT_GUID = process.env.CHAT_GUID;
+const IMAGE_PATHS = (process.env.IMAGE_PATHS || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+const DEFAULT_IMAGE_PATHS = [
+    path.join(__dirname, "test-image.png"),
+    path.join(__dirname, "test-image.png"),
+];
+
+async function main() {
+    const sdk = createSDK();
+
+    sdk.on("ready", async () => {
+        if (!CHAT_GUID) {
+            console.error("CHAT_GUID is required and should be an existing chat GUID for multipart sends");
+            await sdk.close();
+            process.exit(1);
+        }
+
+        const imagePaths = IMAGE_PATHS.length > 0 ? IMAGE_PATHS : DEFAULT_IMAGE_PATHS;
+
+        const missing = imagePaths.filter((filePath) => !fs.existsSync(filePath));
+        if (missing.length > 0) {
+            console.error("missing files:");
+            for (const filePath of missing) {
+                console.error(`- ${filePath}`);
+            }
+            await sdk.close();
+            process.exit(1);
+        }
+
+        try {
+            const message = await sdk.messages.sendMultipartMessage({
+                chatGuid: CHAT_GUID,
+                parts: imagePaths.map((filePath, index) => ({
+                    partIndex: index,
+                    filePath,
+                    fileName: path.basename(filePath),
+                })),
+            });
+
+            const sentMessage = await sdk.messages.getMessage(message.guid, {
+                with: ["attachments"],
+            });
+
+            console.log(`sent multipart message: ${message.guid}`);
+            console.log(`attachments: ${sentMessage.attachments?.length ?? 0}`);
+            console.log(`${new Date(message.dateCreated).toLocaleString()}`);
+        } catch (error) {
+            handleError(error, "Failed to send multipart images");
+        }
+
+        await sdk.close();
+        process.exit(0);
+    });
+
+    await sdk.connect();
+}
+
+main().catch(console.error);

--- a/examples/message-multipart-images.ts
+++ b/examples/message-multipart-images.ts
@@ -8,10 +8,7 @@ const IMAGE_PATHS = (process.env.IMAGE_PATHS || "")
     .map((value) => value.trim())
     .filter(Boolean);
 
-const DEFAULT_IMAGE_PATHS = [
-    path.join(__dirname, "test-image.png"),
-    path.join(__dirname, "test-image.png"),
-];
+const DEFAULT_IMAGE_PATHS = [path.join(__dirname, "test-image.png"), path.join(__dirname, "test-image.png")];
 
 async function main() {
     const sdk = createSDK();

--- a/modules/message.ts
+++ b/modules/message.ts
@@ -17,8 +17,10 @@ export class MessageModule {
         private readonly enqueueSend: <T>(task: () => Promise<T>) => Promise<T> = (task) => task(),
     ) {}
 
-    private async uploadMultipartAttachment(part: Extract<SendMultipartMessagePart, { filePath: string }>) {
-        const fileName = part.fileName || path.basename(part.filePath);
+    private async uploadMultipartAttachment(
+        part: Extract<SendMultipartMessagePart, { filePath: string }>,
+        fileName = part.fileName || path.basename(part.filePath),
+    ) {
         const fileBuffer = await readFile(part.filePath);
         const form = new FormData();
         form.append("attachment", fileBuffer, fileName);
@@ -66,28 +68,35 @@ export class MessageModule {
         return this.enqueueSend(async () => {
             const tempGuid = options.tempGuid || randomUUID();
 
+            const buildPayloadPart = async (part: SendMultipartMessagePart, index: number) => {
+                const resolvedPartIndex = part.partIndex ?? index;
+
+                if ("text" in part) {
+                    return {
+                        partIndex: resolvedPartIndex,
+                        text: part.text,
+                        ...(part.mention ? { mention: part.mention } : {}),
+                    };
+                }
+
+                const fileName = part.fileName || path.basename(part.filePath);
+                const uploadedPath = await this.uploadMultipartAttachment(part, fileName);
+
+                return {
+                    partIndex: resolvedPartIndex,
+                    attachment: uploadedPath,
+                    name: fileName,
+                };
+            };
+
             const uploadParts = async () => {
-                return await Promise.all(
-                    options.parts.map(async (part, index) => {
-                        const resolvedPartIndex = part.partIndex ?? index;
+                const parts: Awaited<ReturnType<typeof buildPayloadPart>>[] = [];
 
-                        if ("text" in part) {
-                            return {
-                                partIndex: resolvedPartIndex,
-                                text: part.text,
-                                ...(part.mention ? { mention: part.mention } : {}),
-                            };
-                        }
+                for (const [index, part] of options.parts.entries()) {
+                    parts.push(await buildPayloadPart(part, index));
+                }
 
-                        const uploadedPath = await this.uploadMultipartAttachment(part);
-
-                        return {
-                            partIndex: resolvedPartIndex,
-                            attachment: uploadedPath,
-                            name: part.fileName || path.basename(uploadedPath),
-                        };
-                    }),
-                );
+                return parts;
             };
 
             const send = async (chatGuid: string) => {

--- a/modules/message.ts
+++ b/modules/message.ts
@@ -1,13 +1,34 @@
 import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import type { AxiosInstance } from "axios";
+import FormData from "form-data";
 import { createChatWithMessage, extractAddress, extractService, isChatNotExistError } from "../lib/auto-create-chat";
-import type { MessageResponse, SendMessageOptions } from "../types";
+import type {
+    MessageResponse,
+    SendMessageOptions,
+    SendMultipartMessageOptions,
+    SendMultipartMessagePart,
+} from "../types";
 
 export class MessageModule {
     constructor(
         private readonly http: AxiosInstance,
         private readonly enqueueSend: <T>(task: () => Promise<T>) => Promise<T> = (task) => task(),
     ) {}
+
+    private async uploadMultipartAttachment(part: Extract<SendMultipartMessagePart, { filePath: string }>) {
+        const fileName = part.fileName || path.basename(part.filePath);
+        const fileBuffer = await readFile(part.filePath);
+        const form = new FormData();
+        form.append("attachment", fileBuffer, fileName);
+
+        const response = await this.http.post("/api/v1/attachment/upload", form, {
+            headers: form.getHeaders(),
+        });
+
+        return response.data.data.path as string;
+    }
 
     async sendMessage(options: SendMessageOptions): Promise<MessageResponse> {
         return this.enqueueSend(async () => {
@@ -37,6 +58,66 @@ export class MessageModule {
                     service,
                 });
                 return { guid: tempGuid, text: options.message, dateCreated: Date.now() } as MessageResponse;
+            }
+        });
+    }
+
+    async sendMultipartMessage(options: SendMultipartMessageOptions): Promise<MessageResponse> {
+        return this.enqueueSend(async () => {
+            const tempGuid = options.tempGuid || randomUUID();
+
+            const uploadParts = async () => {
+                return await Promise.all(
+                    options.parts.map(async (part, index) => {
+                        const resolvedPartIndex = part.partIndex ?? index;
+
+                        if ("text" in part) {
+                            return {
+                                partIndex: resolvedPartIndex,
+                                text: part.text,
+                                ...(part.mention ? { mention: part.mention } : {}),
+                            };
+                        }
+
+                        const uploadedPath = await this.uploadMultipartAttachment(part);
+
+                        return {
+                            partIndex: resolvedPartIndex,
+                            attachment: uploadedPath,
+                            name: part.fileName || path.basename(uploadedPath),
+                        };
+                    }),
+                );
+            };
+
+            const send = async (chatGuid: string) => {
+                const parts = await uploadParts();
+                const payload = {
+                    chatGuid,
+                    tempGuid,
+                    parts,
+                    subject: options.subject,
+                    effectId: options.effectId,
+                    selectedMessageGuid: options.selectedMessageGuid,
+                    partIndex: options.partIndex ?? 0,
+                    ddScan: options.ddScan ?? false,
+                    attributedBody: options.attributedBody,
+                };
+
+                const response = await this.http.post("/api/v1/message/multipart", payload);
+                return response.data.data as MessageResponse;
+            };
+
+            try {
+                return await send(options.chatGuid);
+            } catch (error: unknown) {
+                if (isChatNotExistError(error)) {
+                    throw new Error(
+                        "Chat does not exist for multipart send. Use an existing chatGuid, or create the chat first before calling sendMultipartMessage().",
+                    );
+                }
+
+                throw error;
             }
         });
     }

--- a/types/message.ts
+++ b/types/message.ts
@@ -41,6 +41,30 @@ export interface SendMessageOptions {
     bubbleEffect?: BubbleEffect;
 }
 
+export type SendMultipartMessagePart =
+    | {
+          partIndex?: number;
+          text: string;
+          mention?: Record<string, unknown>;
+      }
+    | {
+          partIndex?: number;
+          filePath: string;
+          fileName?: string;
+      };
+
+export interface SendMultipartMessageOptions {
+    chatGuid: string;
+    parts: SendMultipartMessagePart[];
+    tempGuid?: string;
+    subject?: string;
+    effectId?: string;
+    selectedMessageGuid?: string;
+    partIndex?: number;
+    ddScan?: boolean;
+    attributedBody?: Record<string, unknown> | Record<string, unknown>[];
+}
+
 export interface SendIMessageAppOptions {
     chatGuid: string;
     balloonBundleId: string;


### PR DESCRIPTION
## Summary

Add SDK support for sending multiple images in a single multipart iMessage request.

## Changes

- add `messages.sendMultipartMessage()` to the SDK
- add multipart message request types
- add an example for sending multiple images in one request
- document multipart image sends in the README
- clarify remote SDK file upload behavior in the README

## Details

`sendMultipartMessage()` reads local files on the SDK host, uploads them to the server, and then sends them together in a single `/api/v1/message/multipart` request.

This flow requires:
- a server with Private API support
- an existing `chatGuid`
- file paths that exist on the SDK machine

## Example

```ts
const message = await sdk.messages.sendMultipartMessage({
  chatGuid: "iMessage;+;chat123456789",
  parts: [
    { partIndex: 0, filePath: "/path/to/image-1.jpg" },
    { partIndex: 1, filePath: "/path/to/image-2.jpg" },
    { partIndex: 2, filePath: "/path/to/image-3.jpg" },
  ],
});
```

## Validation

- verified the SDK compiles with `tsc --noEmit`
- verified the multipart flow end to end against a running server
- confirmed that a single multipart message can contain multiple uploaded images

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-kit/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multipart message sending: send multiple images/content in a single request.

* **Documentation**
  * Clarified remote server setup behavior for file paths and uploads when the SDK and server run on different machines.
  * Added guidance and requirements for sending multiple images in one request.

* **Examples**
  * New runnable example demonstrating multipart image sending with file validation and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->