### PR TITLE
feat: opt into Blacksmith Linux runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,5 @@ jobs:
     with:
       service-name: advanced-imessage-kit
       build-command: "bun run build"
+      use-blacksmith: true
     secrets: inherit


### PR DESCRIPTION
Set use-blacksmith: true on the buildspace workflow call so release
builds run on blacksmith-4vcpu-ubuntu-2404 instead of ubuntu-latest.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-kit/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to improve build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->